### PR TITLE
Revert "filter idle schedules with no consumption"

### DIFF
--- a/src/strategy-battery-charging-functions.js
+++ b/src/strategy-battery-charging-functions.js
@@ -163,11 +163,6 @@ const toSchedule = (props, phenotype) => {
       continue
     }
 
-    if (period.activity === 0 && period.charge === 0 && period.cost === 0) {
-      // we probably do not need to be idle here, this seems to happen during PV production
-      continue
-    }
-
     if (schedule.length && period.activity == schedule.at(-1).activity) {
       schedule.at(-1).duration += period.duration
       schedule.at(-1).cost += period.cost


### PR DESCRIPTION
duration needs to be added to next schedule if it is charging, so reverting for now and trying to add tests with multiple szenarios